### PR TITLE
Apply pattern instead of keyword for terraform blocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,12 +84,11 @@ const STRINGS: Mode = {
 	],
 };
 
-const TOP_LEVEL_BLOCKS: Mode = {
+const BLOCKS: Mode = {
 	contains: [
 		{
 			className: "keyword",
-			begin:
-				"\\b(resource|variable|output|data|locals|terraform|provider|module)\\b(?!\\s*=)",
+			begin: "^\\s*\\b[a-zA-Z_][a-zA-Z0-9_]*\\b(?!\\s*=)",
 			end: '(?=\\s*["\\{])',
 			excludeEnd: true,
 		},
@@ -101,7 +100,7 @@ const ALIASES = ["tf", "hcl"];
 const hljsDefineTerraform: LanguageFn = (hljs: HLJSApi): Language => {
 	return {
 		aliases: ALIASES,
-		contains: [hljs.COMMENT("\\#", "$"), NUMBERS, STRINGS, TOP_LEVEL_BLOCKS],
+		contains: [hljs.COMMENT("\\#", "$"), NUMBERS, STRINGS, BLOCKS],
 	};
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,8 @@ const BLOCKS: Mode = {
 	contains: [
 		{
 			className: "keyword",
-			begin: "^\\s*\\b[a-zA-Z_][a-zA-Z0-9_]*\\b(?!\\s*=)",
-			end: '(?=\\s*["\\{])',
-			excludeEnd: true,
+			// NOTE: highlight.js does not highlight words captured by lookahead assertions.
+			begin: '^\\s*\\b[a-zA-Z_][a-zA-Z0-9_]*\\b(?=\\s*["\\{])',
 		},
 	],
 };

--- a/src/spec/__snapshots__/terraform.spec.ts.snap
+++ b/src/spec/__snapshots__/terraform.spec.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`highlight bundle > highlights terraform (base-input) 1`] = `
 "<span class="hljs-comment"># Terraform (hcl)</span>
-
-<span class="hljs-keyword">variable</span> <span class="hljs-string">&quot;string&quot;</span> {
+<span class="hljs-keyword">
+variable</span> <span class="hljs-string">&quot;string&quot;</span> {
   default = <span class="hljs-string">&quot;string_test&quot;</span> <span class="hljs-comment"># test inline comment</span>
 }
-
-<span class="hljs-keyword">resource</span> <span class="hljs-string">&quot;azurerm_subnet&quot;</span> <span class="hljs-string">&quot;sn1&quot;</span> {
+<span class="hljs-keyword">
+resource</span> <span class="hljs-string">&quot;azurerm_subnet&quot;</span> <span class="hljs-string">&quot;sn1&quot;</span> {
   count                = <span class="hljs-number">1</span>
   number               = <span class="hljs-number">2.3</span>
   boolean              = true
@@ -19,14 +19,14 @@ exports[`highlight bundle > highlights terraform (base-input) 1`] = `
 
   tags = <span class="hljs-string">&quot;<span class="hljs-variable">\${<span class="hljs-meta">merge(local.tags, <span class="hljs-meta">map(<span class="hljs-string">&quot;update&quot;</span>,<span class="hljs-string">&quot;<span class="hljs-variable">\${<span class="hljs-meta">timestamp()</span>}</span>&quot;</span>)</span>)</span>}</span>&quot;</span>
 }
-
-<span class="hljs-keyword">output</span> <span class="hljs-string">&quot;public_ip_address&quot;</span> {
+<span class="hljs-keyword">
+output</span> <span class="hljs-string">&quot;public_ip_address&quot;</span> {
   value = [<span class="hljs-string">&quot;<span class="hljs-variable">\${azurerm_public_ip.pip1.*.ip_address}</span>&quot;</span>]
 }
+<span class="hljs-keyword">
 
-
-<span class="hljs-keyword">terraform</span> {
-  backend <span class="hljs-string">&quot;azure&quot;</span> {
+terraform</span> {
+<span class="hljs-keyword">  backend</span> <span class="hljs-string">&quot;azure&quot;</span> {
     storage_account_name = <span class="hljs-string">&quot;azure&quot;</span>
   }
 }


### PR DESCRIPTION
![スクリーンショット 2025-06-01 12 49 16](https://github.com/user-attachments/assets/312b3cce-7f0d-45f5-9823-8e7ce53e4906)

We can highlight terraform blocks like this.