### PR TITLE
Add highlighting for bool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,15 @@ const NUMBERS: Mode = {
 };
 
 /**
+ * {@link https://developer.hashicorp.com/terraform/language/expressions/types#bool}
+ */
+const BOOLS: Mode = {
+	className: "literal",
+	begin: "\\b(true|false)\\b",
+	relevance: 0,
+};
+
+/**
  * {@link https://developer.hashicorp.com/terraform/language/expressions/types#strings}
  * {@link https://developer.hashicorp.com/terraform/language/expressions/strings}
  */
@@ -108,7 +117,7 @@ const ALIASES = ["tf", "hcl"];
 const hljsDefineTerraform: LanguageFn = (hljs: HLJSApi): Language => {
 	return {
 		aliases: ALIASES,
-		contains: [hljs.COMMENT("\\#", "$"), NUMBERS, STRINGS, BLOCKS],
+		contains: [hljs.COMMENT("\\#", "$"), NUMBERS, STRINGS, BOOLS, BLOCKS],
 	};
 };
 

--- a/src/spec/__snapshots__/terraform.spec.ts.snap
+++ b/src/spec/__snapshots__/terraform.spec.ts.snap
@@ -10,7 +10,7 @@ variable</span> <span class="hljs-string">&quot;string&quot;</span> {
 resource</span> <span class="hljs-string">&quot;azurerm_subnet&quot;</span> <span class="hljs-string">&quot;sn1&quot;</span> {
   count                = <span class="hljs-number">1</span>
   number               = <span class="hljs-number">2.3</span>
-  boolean              = true
+  boolean              = <span class="hljs-literal">true</span>
   type                 = <span class="hljs-string">&quot;<span class="hljs-variable">\${var.string}</span>&quot;</span>
   name                 = <span class="hljs-string">&quot;<span class="hljs-variable">\${var.prefix}</span>-sn&quot;</span>
   resource_group_name  = <span class="hljs-string">&quot;<span class="hljs-variable">\${azurerm_resource_group.rg1.name}</span>&quot;</span>


### PR DESCRIPTION
This pull request enhances syntax highlighting for Terraform files by adding support for boolean literals and updating snapshots accordingly. The most important changes include defining a new `BOOLS` mode, integrating it into the language definition, and updating the snapshot tests to reflect the new behavior.

### Syntax Highlighting Enhancements:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R23-R31): Added a new `BOOLS` mode to support highlighting of boolean literals (`true` and `false`) with zero relevance.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L111-R120): Updated the `hljsDefineTerraform` function to include the `BOOLS` mode in the `contains` array for proper syntax recognition.

### Snapshot Updates:
* [`src/spec/__snapshots__/terraform.spec.ts.snap`](diffhunk://#diff-2f803127c1ad9d84a7bf6b2f103c37f7ed1d8a3bba184ee5665e09115fe2b06fL13-R13): Modified snapshots to ensure boolean literals are highlighted using the new `hljs-literal` class instead of the default formatting.