### PR TITLE
Fix to change from variable to subst

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ const STRINGS: Mode = {
 	end: '"',
 	contains: [
 		{
-			className: "variable",
+			className: "subst",
 			begin: "\\${",
 			end: "\\}",
 			relevance: 9,
@@ -61,7 +61,7 @@ const STRINGS: Mode = {
 							end: '"',
 							contains: [
 								{
-									className: "variable",
+									className: "subst",
 									begin: "\\${",
 									end: "\\}",
 									contains: [
@@ -71,7 +71,7 @@ const STRINGS: Mode = {
 											end: '"',
 											contains: [
 												{
-													className: "variable",
+													className: "subst",
 													begin: "\\${",
 													end: "\\}",
 												},

--- a/src/spec/__snapshots__/terraform.spec.ts.snap
+++ b/src/spec/__snapshots__/terraform.spec.ts.snap
@@ -11,17 +11,17 @@ resource</span> <span class="hljs-string">&quot;azurerm_subnet&quot;</span> <spa
   count                = <span class="hljs-number">1</span>
   number               = <span class="hljs-number">2.3</span>
   boolean              = <span class="hljs-literal">true</span>
-  type                 = <span class="hljs-string">&quot;<span class="hljs-variable">\${var.string}</span>&quot;</span>
-  name                 = <span class="hljs-string">&quot;<span class="hljs-variable">\${var.prefix}</span>-sn&quot;</span>
-  resource_group_name  = <span class="hljs-string">&quot;<span class="hljs-variable">\${azurerm_resource_group.rg1.name}</span>&quot;</span>
-  virtual_network      = <span class="hljs-string">&quot;<span class="hljs-variable">\${<span class="hljs-meta">cidrsubnet(<span class="hljs-string">&quot;test&quot;</span>,<span class="hljs-number">3</span>,<span class="hljs-meta">test()</span>)</span>}</span>&quot;</span>
-  address_prefix       = <span class="hljs-string">&quot;<span class="hljs-variable">\${<span class="hljs-meta">cidrsubnet(<span class="hljs-string">&quot;<span class="hljs-variable">\${var.vnets[<span class="hljs-string">&quot;<span class="hljs-variable">\${var.location}</span>&quot;</span>,<span class="hljs-string">&quot;test1&quot;</span>]}</span>&quot;</span>,<span class="hljs-string">&quot;<span class="hljs-variable">\${var.network_size}</span>&quot;</span>,<span class="hljs-number">3</span>,<span class="hljs-string">&quot;test&quot;</span>)</span>}</span>&quot;</span>
+  type                 = <span class="hljs-string">&quot;<span class="hljs-subst">\${var.string}</span>&quot;</span>
+  name                 = <span class="hljs-string">&quot;<span class="hljs-subst">\${var.prefix}</span>-sn&quot;</span>
+  resource_group_name  = <span class="hljs-string">&quot;<span class="hljs-subst">\${azurerm_resource_group.rg1.name}</span>&quot;</span>
+  virtual_network      = <span class="hljs-string">&quot;<span class="hljs-subst">\${<span class="hljs-meta">cidrsubnet(<span class="hljs-string">&quot;test&quot;</span>,<span class="hljs-number">3</span>,<span class="hljs-meta">test()</span>)</span>}</span>&quot;</span>
+  address_prefix       = <span class="hljs-string">&quot;<span class="hljs-subst">\${<span class="hljs-meta">cidrsubnet(<span class="hljs-string">&quot;<span class="hljs-subst">\${var.vnets[<span class="hljs-string">&quot;<span class="hljs-subst">\${var.location}</span>&quot;</span>,<span class="hljs-string">&quot;test1&quot;</span>]}</span>&quot;</span>,<span class="hljs-string">&quot;<span class="hljs-subst">\${var.network_size}</span>&quot;</span>,<span class="hljs-number">3</span>,<span class="hljs-string">&quot;test&quot;</span>)</span>}</span>&quot;</span>
 
-  tags = <span class="hljs-string">&quot;<span class="hljs-variable">\${<span class="hljs-meta">merge(local.tags, <span class="hljs-meta">map(<span class="hljs-string">&quot;update&quot;</span>,<span class="hljs-string">&quot;<span class="hljs-variable">\${<span class="hljs-meta">timestamp()</span>}</span>&quot;</span>)</span>)</span>}</span>&quot;</span>
+  tags = <span class="hljs-string">&quot;<span class="hljs-subst">\${<span class="hljs-meta">merge(local.tags, <span class="hljs-meta">map(<span class="hljs-string">&quot;update&quot;</span>,<span class="hljs-string">&quot;<span class="hljs-subst">\${<span class="hljs-meta">timestamp()</span>}</span>&quot;</span>)</span>)</span>}</span>&quot;</span>
 }
 <span class="hljs-keyword">
 output</span> <span class="hljs-string">&quot;public_ip_address&quot;</span> {
-  value = [<span class="hljs-string">&quot;<span class="hljs-variable">\${azurerm_public_ip.pip1.*.ip_address}</span>&quot;</span>]
+  value = [<span class="hljs-string">&quot;<span class="hljs-subst">\${azurerm_public_ip.pip1.*.ip_address}</span>&quot;</span>]
 }
 <span class="hljs-keyword">
 


### PR DESCRIPTION
This pull request includes changes to standardize the use of the `subst` class for string interpolation across multiple files. The updates replace the `variable` class with `subst` to ensure consistency and improve readability in highlighted code sections.

### Standardization of string interpolation classes:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L42-R42): Updated occurrences of `className: "variable"` to `className: "subst"` within the `STRINGS` mode configuration to standardize string interpolation handling. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L42-R42) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L64-R64) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L74-R74)

* [`src/spec/__snapshots__/terraform.spec.ts.snap`](diffhunk://#diff-2f803127c1ad9d84a7bf6b2f103c37f7ed1d8a3bba184ee5665e09115fe2b06fL14-R24): Replaced `hljs-variable` with `hljs-subst` in snapshot tests for Terraform syntax highlighting to align with the updated string interpolation class.