### PR TITLE
Add terraform functions highlighting, and add some comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,9 @@ const BOOLS: Mode = {
 	relevance: 0,
 };
 
+const FUNCTION_SYMBOL_REGEX_BEGIN = "[A-Za-z_0-9]+\\(";
+const FUNCTION_SYMBOL_REGEX_END = "\\)";
+
 /**
  * {@link https://developer.hashicorp.com/terraform/language/expressions/types#strings}
  * {@link https://developer.hashicorp.com/terraform/language/expressions/strings}
@@ -53,8 +56,8 @@ const STRINGS: Mode = {
 				},
 				{
 					className: "meta",
-					begin: "[A-Za-z_0-9]+\\(",
-					end: "\\)",
+					begin: FUNCTION_SYMBOL_REGEX_BEGIN,
+					end: FUNCTION_SYMBOL_REGEX_END,
 					contains: [
 						NUMBERS,
 						{
@@ -81,8 +84,8 @@ const STRINGS: Mode = {
 										},
 										{
 											className: "meta",
-											begin: "[A-Za-z_0-9]+\\(",
-											end: "\\)",
+											begin: FUNCTION_SYMBOL_REGEX_BEGIN,
+											end: FUNCTION_SYMBOL_REGEX_END,
 										},
 									],
 								},
@@ -101,8 +104,8 @@ const STRINGS: Mode = {
  */
 const FUNCTIONS: Mode = {
 	className: "meta",
-	begin: "[A-Za-z_0-9]+\\(",
-	end: "\\)",
+	begin: FUNCTION_SYMBOL_REGEX_BEGIN,
+	end: FUNCTION_SYMBOL_REGEX_END,
 	contains: [NUMBERS, STRINGS, BOOLS, "self"],
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ const BOOLS: Mode = {
 /**
  * {@link https://developer.hashicorp.com/terraform/language/expressions/types#strings}
  * {@link https://developer.hashicorp.com/terraform/language/expressions/strings}
+ * TODO: We need to simplify this complex string definition using recursive method to generate
+ * nested strings.
  */
 const STRINGS: Mode = {
 	className: "string",
@@ -79,7 +81,7 @@ const STRINGS: Mode = {
 										},
 										{
 											className: "meta",
-											begin: "[A-Za-z_0-9]*" + "\\(",
+											begin: "[A-Za-z_0-9]*\\(",
 											end: "\\)",
 										},
 									],
@@ -92,6 +94,16 @@ const STRINGS: Mode = {
 			],
 		},
 	],
+};
+
+/**
+ * {@link https://developer.hashicorp.com/terraform/language/functions}
+ */
+const FUNCTIONS: Mode = {
+	className: "meta",
+	begin: "\\b[A-Za-z_0-9]+\\(",
+	end: "\\)",
+	contains: [NUMBERS, STRINGS, BOOLS, "self"],
 };
 
 /**
@@ -117,7 +129,14 @@ const ALIASES = ["tf", "hcl"];
 const hljsDefineTerraform: LanguageFn = (hljs: HLJSApi): Language => {
 	return {
 		aliases: ALIASES,
-		contains: [hljs.COMMENT("\\#", "$"), NUMBERS, STRINGS, BOOLS, BLOCKS],
+		contains: [
+			hljs.COMMENT("\\#", "$"),
+			NUMBERS,
+			BOOLS,
+			STRINGS,
+			FUNCTIONS,
+			BLOCKS,
+		],
 	};
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ const STRINGS: Mode = {
 				},
 				{
 					className: "meta",
-					begin: "[A-Za-z_0-9]*\\(",
+					begin: "[A-Za-z_0-9]+\\(",
 					end: "\\)",
 					contains: [
 						NUMBERS,
@@ -81,7 +81,7 @@ const STRINGS: Mode = {
 										},
 										{
 											className: "meta",
-											begin: "[A-Za-z_0-9]*\\(",
+											begin: "[A-Za-z_0-9]+\\(",
 											end: "\\)",
 										},
 									],
@@ -101,7 +101,7 @@ const STRINGS: Mode = {
  */
 const FUNCTIONS: Mode = {
 	className: "meta",
-	begin: "\\b[A-Za-z_0-9]+\\(",
+	begin: "[A-Za-z_0-9]+\\(",
 	end: "\\)",
 	contains: [NUMBERS, STRINGS, BOOLS, "self"],
 };


### PR DESCRIPTION
This pull request introduces improvements to the `src/index.ts` file for better handling of Terraform language syntax highlighting. The key changes include adding a new `FUNCTIONS` mode for recognizing Terraform functions, simplifying the `STRINGS` mode definition, and updating the language definition to include the new mode.

Enhancements to syntax highlighting:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R99-R108): Added a new `FUNCTIONS` mode to recognize Terraform function calls, including nested structures. This mode supports patterns like `functionName()`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L82-R84): Updated the `STRINGS` mode by simplifying the `begin` regex pattern for better readability and maintainability.

General improvements:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L120-R139): Updated the main Terraform language definition (`hljsDefineTerraform`) to include the new `FUNCTIONS` mode in the `contains` array, ensuring functions are properly highlighted.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R35-R36): Added a TODO comment suggesting the use of a recursive method to simplify complex string definitions in the future.