### PR TITLE
Add snapshot tests

### DIFF
--- a/src/spec/__snapshots__/terraform.spec.ts.snap
+++ b/src/spec/__snapshots__/terraform.spec.ts.snap
@@ -32,3 +32,56 @@ terraform</span> {
 }
 "
 `;
+
+exports[`highlight bundle > highlights terraform (base2-input) 1`] = `
+"<span class="hljs-keyword">terraform</span> {
+<span class="hljs-keyword">  required_providers</span> {
+    aws = {
+      source = <span class="hljs-string">&quot;hashicorp/aws&quot;</span>
+    }
+  }
+}
+<span class="hljs-keyword">
+provider</span> <span class="hljs-string">&quot;aws&quot;</span> {
+  alias   = <span class="hljs-string">&quot;user&quot;</span>
+  region  = var.region
+  profile = var.profile
+}
+<span class="hljs-keyword">resource</span> <span class="hljs-string">&quot;aws_s3_bucket&quot;</span> <span class="hljs-string">&quot;example&quot;</span> {
+  provider      = aws.user
+  bucket        = var.bucket_name
+  acl           = var.acl_value
+  force_destroy = <span class="hljs-string">&quot;false&quot;</span>
+}
+<span class="hljs-keyword">
+resource</span> <span class="hljs-string">&quot;aws_s3_bucket_object&quot;</span> <span class="hljs-string">&quot;object2&quot;</span> {
+  for_each = <span class="hljs-meta">fileset(<span class="hljs-string">&quot;myfiles/&quot;</span>, <span class="hljs-string">&quot;*&quot;</span>)</span>
+  bucket   = aws_s3_bucket.example.bucket
+  key      = <span class="hljs-string">&quot;new_objects&quot;</span>
+  source   = <span class="hljs-string">&quot;myfiles/<span class="hljs-subst">\${each.value}</span>&quot;</span>
+  etag     = <span class="hljs-meta">filemd5(<span class="hljs-string">&quot;myfiles/<span class="hljs-subst">\${each.value}</span>&quot;</span>)</span>
+}
+"
+`;
+
+exports[`highlight bundle > highlights terraform (base3-input) 1`] = `
+"<span class="hljs-keyword">locals</span> {
+    subnet_map_list = [
+        { <span class="hljs-string">&quot;name&quot;</span> = <span class="hljs-string">&quot;sample-subnet1&quot;</span>, <span class="hljs-string">&quot;cidr&quot;</span> = <span class="hljs-string">&quot;10.0.101.0/24&quot;</span>, <span class="hljs-string">&quot;az_name&quot;</span> = <span class="hljs-string">&quot;ap-northeast-1a&quot;</span> },
+        { <span class="hljs-string">&quot;name&quot;</span> = <span class="hljs-string">&quot;sample-subnet2&quot;</span>, <span class="hljs-string">&quot;cidr&quot;</span> = <span class="hljs-string">&quot;10.0.102.0/24&quot;</span>, <span class="hljs-string">&quot;az_name&quot;</span> = <span class="hljs-string">&quot;ap-northeast-1c&quot;</span> },
+        { <span class="hljs-string">&quot;name&quot;</span> = <span class="hljs-string">&quot;sample-subnet3&quot;</span>, <span class="hljs-string">&quot;cidr&quot;</span> = <span class="hljs-string">&quot;10.0.103.0/24&quot;</span>, <span class="hljs-string">&quot;az_name&quot;</span> = <span class="hljs-string">&quot;ap-northeast-1c&quot;</span> },
+    ]
+}
+<span class="hljs-keyword">
+resource</span> <span class="hljs-string">&quot;aws_subnet&quot;</span> <span class="hljs-string">&quot;subnet&quot;</span> {
+    for_each = { for subnet in local.subnet_map_list : subnet.name =&gt; subnet }
+
+    vpc_id = aws_vpc.vpc.id
+    cidr_block = each.value.cidr
+    availability_zone = each.value.az_name
+    tags = {
+        Name = each.key
+    }
+}
+"
+`;

--- a/src/spec/base2-input.txt
+++ b/src/spec/base2-input.txt
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  alias   = "user"
+  region  = var.region
+  profile = var.profile
+}
+resource "aws_s3_bucket" "example" {
+  provider      = aws.user
+  bucket        = var.bucket_name
+  acl           = var.acl_value
+  force_destroy = "false"
+}
+
+resource "aws_s3_bucket_object" "object2" {
+  for_each = fileset("myfiles/", "*")
+  bucket   = aws_s3_bucket.example.bucket
+  key      = "new_objects"
+  source   = "myfiles/${each.value}"
+  etag     = filemd5("myfiles/${each.value}")
+}

--- a/src/spec/base3-input.txt
+++ b/src/spec/base3-input.txt
@@ -1,0 +1,18 @@
+locals {
+    subnet_map_list = [
+        { "name" = "sample-subnet1", "cidr" = "10.0.101.0/24", "az_name" = "ap-northeast-1a" },
+        { "name" = "sample-subnet2", "cidr" = "10.0.102.0/24", "az_name" = "ap-northeast-1c" },
+        { "name" = "sample-subnet3", "cidr" = "10.0.103.0/24", "az_name" = "ap-northeast-1c" },
+    ]
+}
+
+resource "aws_subnet" "subnet" {
+    for_each = { for subnet in local.subnet_map_list : subnet.name => subnet }
+
+    vpc_id = aws_vpc.vpc.id
+    cidr_block = each.value.cidr
+    availability_zone = each.value.az_name
+    tags = {
+        Name = each.key
+    }
+}

--- a/src/spec/terraform.spec.ts
+++ b/src/spec/terraform.spec.ts
@@ -22,4 +22,32 @@ describe("highlight bundle", () => {
 		expect(language).toBe("terraform");
 		expect(result).toMatchSnapshot();
 	});
+
+	it("highlights terraform (base2-input)", () => {
+		const input = fs.readFileSync(
+			path.resolve(__dirname, "./base2-input.txt"),
+			"utf-8",
+		);
+
+		const { value: result, language } = hljs.highlightAuto(input, [
+			"terraform",
+		]);
+
+		expect(language).toBe("terraform");
+		expect(result).toMatchSnapshot();
+	});
+
+	it("highlights terraform (base3-input)", () => {
+		const input = fs.readFileSync(
+			path.resolve(__dirname, "./base3-input.txt"),
+			"utf-8",
+		);
+
+		const { value: result, language } = hljs.highlightAuto(input, [
+			"terraform",
+		]);
+
+		expect(language).toBe("terraform");
+		expect(result).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
This pull request introduces new test cases and snapshots for highlighting Terraform configurations using `highlight.js`. It adds support for two distinct input formats (`base2-input` and `base3-input`) and ensures the syntax highlighting behaves as expected for these cases.

### Added test cases for Terraform syntax highlighting:

* [`src/spec/terraform.spec.ts`](diffhunk://#diff-16136168d8de0e7ad221d74d865d6f274d055592f57a0ffb151b876b0a781271R25-R52): Added two new test cases (`base2-input` and `base3-input`) to validate syntax highlighting for Terraform configurations. Each test reads the corresponding input file and checks the highlighted output against snapshots.

### Added input files for new test cases:

* [`src/spec/base2-input.txt`](diffhunk://#diff-966a65b02988126aab493945ee2142096da5aa0824c8491d9de19ae7681bb823R1-R27): Contains a sample Terraform configuration with resources like `aws_s3_bucket` and `aws_s3_bucket_object`. This file serves as input for the `base2-input` test.
* [`src/spec/base3-input.txt`](diffhunk://#diff-8889eb6d24a1b4b7e907a641dfc828f4a04a0ba0416c4af34eb8e671f4db3890R1-R18): Contains a sample Terraform configuration with `locals` and `aws_subnet` resources. This file serves as input for the `base3-input` test.

### Updated snapshots for Terraform syntax highlighting:

* [`src/spec/__snapshots__/terraform.spec.ts.snap`](diffhunk://#diff-2f803127c1ad9d84a7bf6b2f103c37f7ed1d8a3bba184ee5665e09115fe2b06fR35-R87): Added snapshots for the highlighted output of `base2-input` and `base3-input` configurations. These snapshots ensure the correctness of syntax highlighting for Terraform code.

issue: #5 